### PR TITLE
fix: support subclasses of competition-format

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,6 +14,7 @@ services:
       - DB_PORT=27017
       - DB_USER=${DB_USER}
       - DB_PASSWORD=${DB_PASSWORD}
+      - LOGGING_LEVEL=${LOGGING_LEVEL}
     depends_on:
       - user-service
       - mongodb

--- a/mypy.ini
+++ b/mypy.ini
@@ -41,3 +41,6 @@ ignore_missing_imports = True
 
 [mypy-jwt.*]
 ignore_missing_imports = True
+
+[mypy-marshmallow.*]
+ignore_missing_imports = True

--- a/noxfile.py
+++ b/noxfile.py
@@ -95,6 +95,7 @@ def contract_tests(session: Session) -> None:
             "JWT_EXP_DELTA_SECONDS": "60",
             "DB_USER": "event-service",
             "DB_PASSWORD": "password",
+            "LOGGING_LEVEL": "DEBUG",
         },
     )
 

--- a/src/event_service/adapters/competition_formats_adapter.py
+++ b/src/event_service/adapters/competition_formats_adapter.py
@@ -41,13 +41,14 @@ class CompetitionFormatsAdapter(Adapter):
         cls: Any, db: Any, competition_format_name: str
     ) -> List[dict]:  # pragma: no cover
         """Get competition_format by name function."""
+        logging.debug(f"Got request for name {competition_format_name}.")
         competition_formats: List = []
-        cursor = db.competition_formats_collection.find(
-            {"name": competition_format_name}
-        )
+        query = {"$regex": f".*{competition_format_name}.*", "$options": "i"}
+        logging.debug(f"Query: {query}.")
+        cursor = db.competition_formats_collection.find({"name": query})
         for competition_format in await cursor.to_list(None):
+            logging.debug(f"cursor - competition_format: {competition_format}")
             competition_formats.append(competition_format)
-            logging.debug(competition_format)
         return competition_formats
 
     @classmethod

--- a/src/event_service/models/__init__.py
+++ b/src/event_service/models/__init__.py
@@ -1,5 +1,9 @@
 """Package for all models."""
-from .competition_format_model import CompetitionFormat
+from .competition_format_model import (
+    CompetitionFormat,
+    IndividualSprintFormat,
+    IntervalStartFormat,
+)
 from .contestant_model import Contestant
 from .event_model import Event
 from .raceclass_model import Raceclass

--- a/src/event_service/models/competition_format_model.py
+++ b/src/event_service/models/competition_format_model.py
@@ -1,17 +1,48 @@
 """Competition format data class module."""
+from abc import ABC
 from dataclasses import dataclass, field
 from datetime import time
 from typing import Optional
 
 from dataclasses_json import DataClassJsonMixin
+from marshmallow.fields import Constant
 
 
 @dataclass
-class CompetitionFormat(DataClassJsonMixin):
-    """Data class with details about a competition format."""
+class CompetitionFormat(DataClassJsonMixin, ABC):
+    """Abstract data class with details about a competition format."""
+
+    def __post_init__(self) -> None:  # pragma: no cover
+        """Prevent instantiate abstract class."""
+        if self.__class__ == CompetitionFormat:
+            raise TypeError("Cannot instantiate abstract class.")
 
     name: str
     start_procedure: str
-    starting_order: Optional[str] = field(default=None)
-    intervals: Optional[time] = field(default=None)
+    starting_order: str
+
+
+@dataclass
+class IntervalStartFormat(CompetitionFormat, DataClassJsonMixin):
+    """Data class with details about a interval start format."""
+
+    intervals: time
+    datatype: str = field(
+        metadata=dict(marshmallow_field=Constant("interval_start")),
+        default="interval_start",
+    )
+    id: Optional[str] = field(default=None)
+
+
+@dataclass
+class IndividualSprintFormat(CompetitionFormat, DataClassJsonMixin):
+    """Data class with details about a individual sprint format."""
+
+    time_between_rounds: time
+    time_between_heats: time
+    max_no_of_contestants: int
+    datatype: str = field(
+        metadata=dict(marshmallow_field=Constant("individual_sprint")),
+        default="individual_sprint",
+    )
     id: Optional[str] = field(default=None)

--- a/src/event_service/services/event_format_service.py
+++ b/src/event_service/services/event_format_service.py
@@ -4,7 +4,11 @@ from typing import Any, Optional
 import uuid
 
 from event_service.adapters import EventFormatAdapter
-from event_service.models import CompetitionFormat
+from event_service.models import (
+    CompetitionFormat,
+    IndividualSprintFormat,
+    IntervalStartFormat,
+)
 from .events_service import EventNotFoundException, EventsService
 
 
@@ -69,7 +73,10 @@ class EventFormatService:
         event_format = await EventFormatAdapter.get_event_format(db, event_id)
         # return the document if found:
         if event_format:
-            return CompetitionFormat.from_dict(event_format)
+            if event_format["datatype"] == "interval_start":
+                return IntervalStartFormat.from_dict(event_format)
+            elif event_format["datatype"] == "individual_sprint":
+                return IndividualSprintFormat.from_dict(event_format)
         raise EventFormatNotFoundException(
             f"EventFormat with for event id {event_id} not found"
         ) from None

--- a/src/event_service/views/competition_formats.py
+++ b/src/event_service/views/competition_formats.py
@@ -15,7 +15,10 @@ from dotenv import load_dotenv
 from multidict import MultiDict
 
 from event_service.adapters import UsersAdapter
-from event_service.models import CompetitionFormat
+from event_service.models import (
+    IndividualSprintFormat,
+    IntervalStartFormat,
+)
 from event_service.services import (
     CompetitionFormatNotFoundException,
     CompetitionFormatsService,
@@ -61,7 +64,7 @@ class CompetitionFormatsView(View):
         body = json.dumps(result, default=str, ensure_ascii=False)
         return Response(status=200, body=body, content_type="application/json")
 
-    async def post(self) -> Response:
+    async def post(self) -> Response:  # noqa: C901
         """Post route function."""
         db = self.request.app["db"]
         token = extract_token_from_request(self.request)
@@ -75,7 +78,10 @@ class CompetitionFormatsView(View):
             f"Got create request for competition_format {body} of type {type(body)}"
         )
         try:
-            competition_format = CompetitionFormat.from_dict(body)
+            if body["datatype"] == "interval_start":
+                competition_format = IntervalStartFormat.from_dict(body)
+            elif body["datatype"] == "individual_sprint":
+                competition_format = IndividualSprintFormat.from_dict(body)
         except KeyError as e:
             raise HTTPUnprocessableEntity(
                 reason=f"Mandatory property {e.args[0]} is missing."
@@ -132,7 +138,7 @@ class CompetitionFormatView(View):
         body = competition_format.to_json()
         return Response(status=200, body=body, content_type="application/json")
 
-    async def put(self) -> Response:
+    async def put(self) -> Response:  # noqa: C901
         """Put route function."""
         db = self.request.app["db"]
         token = extract_token_from_request(self.request)
@@ -151,7 +157,10 @@ class CompetitionFormatView(View):
             f"Got put request for competition_format {body} of type {type(body)}"
         )
         try:
-            competition_format = CompetitionFormat.from_dict(body)
+            if body["datatype"] == "interval_start":
+                competition_format = IntervalStartFormat.from_dict(body)
+            elif body["datatype"] == "individual_sprint":
+                competition_format = IndividualSprintFormat.from_dict(body)
         except KeyError as e:
             raise HTTPUnprocessableEntity(
                 reason=f"Mandatory property {e.args[0]} is missing."

--- a/src/event_service/views/event_format.py
+++ b/src/event_service/views/event_format.py
@@ -14,7 +14,10 @@ from dotenv import load_dotenv
 from multidict import MultiDict
 
 from event_service.adapters import UsersAdapter
-from event_service.models import CompetitionFormat
+from event_service.models import (
+    IndividualSprintFormat,
+    IntervalStartFormat,
+)
 from event_service.services import (
     EventFormatNotFoundException,
     EventFormatService,
@@ -49,7 +52,10 @@ class EventFormatView(View):
         )
 
         try:
-            event_format = CompetitionFormat.from_dict(body)
+            if body["datatype"] == "interval_start":
+                event_format = IntervalStartFormat.from_dict(body)
+            elif body["datatype"] == "individual_sprint":
+                event_format = IndividualSprintFormat.from_dict(body)
         except KeyError as e:
             raise HTTPUnprocessableEntity(
                 reason=f"Mandatory property {e.args[0]} is missing."
@@ -106,7 +112,10 @@ class EventFormatView(View):
         )
 
         try:
-            event_format = CompetitionFormat.from_dict(body)
+            if body["datatype"] == "interval_start":
+                event_format = IntervalStartFormat.from_dict(body)
+            elif body["datatype"] == "individual_sprint":
+                event_format = IndividualSprintFormat.from_dict(body)
         except KeyError as e:
             raise HTTPUnprocessableEntity(
                 reason=f"Mandatory property {e.args[0]} is missing."

--- a/tests/contract/test_competition_formats.py
+++ b/tests/contract/test_competition_formats.py
@@ -1,8 +1,10 @@
 """Contract test cases for competition-formats."""
+import asyncio
 from copy import deepcopy
 import logging
 import os
 from typing import Any, AsyncGenerator
+from urllib.parse import quote
 
 from aiohttp import ClientSession, hdrs
 import pytest
@@ -12,9 +14,24 @@ USERS_HOST_SERVER = os.getenv("USERS_HOST_SERVER")
 USERS_HOST_PORT = os.getenv("USERS_HOST_PORT")
 
 
-@pytest.fixture
+@pytest.fixture(scope="module")
+def event_loop(request: Any) -> Any:
+    """Redefine the event_loop fixture to have the same scope."""
+    loop = asyncio.get_event_loop_policy().new_event_loop()
+    yield loop
+    loop.close()
+
+
+@pytest.fixture(scope="module")
 @pytest.mark.asyncio
 async def clear_db(http_service: Any, token: MockFixture) -> AsyncGenerator:
+    """Clear DB before and after tests."""
+    await delete_competition_formats(http_service, token)
+    yield
+    await delete_competition_formats(http_service, token)
+
+
+async def delete_competition_formats(http_service: Any, token: MockFixture) -> None:
     """Delete all Competition_formats before we start."""
     url = f"{http_service}/competition-formats"
     headers = {
@@ -31,21 +48,35 @@ async def clear_db(http_service: Any, token: MockFixture) -> AsyncGenerator:
             ) as response:
                 pass
     await session.close()
-    yield
 
 
-@pytest.fixture
-async def competition_format() -> dict:
+@pytest.fixture(scope="module")
+async def competition_format_interval_start() -> dict:
     """An competition_format object for testing."""
     return {
         "name": "Interval Start",
         "starting_order": "Draw",
         "start_procedure": "Interval Start",
         "intervals": "00:00:30",
+        "datatype": "interval_start",
     }
 
 
-@pytest.fixture
+@pytest.fixture(scope="module")
+async def competition_format_individual_sprint() -> dict:
+    """An competition_format object for testing."""
+    return {
+        "name": "Individual Sprint",
+        "starting_order": "Draw",
+        "start_procedure": "Heat Start",
+        "time_between_rounds": "00:05:00",
+        "time_between_heats": "00:02:30",
+        "max_no_of_contestants": 80,
+        "datatype": "individual_sprint",
+    }
+
+
+@pytest.fixture(scope="module")
 @pytest.mark.asyncio
 async def token(http_service: Any) -> str:
     """Create a valid token."""
@@ -66,11 +97,11 @@ async def token(http_service: Any) -> str:
 
 @pytest.mark.contract
 @pytest.mark.asyncio
-async def test_create_competition_format(
+async def test_create_competition_format_interval_start(
     http_service: Any,
     token: MockFixture,
     clear_db: AsyncGenerator,
-    competition_format: dict,
+    competition_format_interval_start: dict,
 ) -> None:
     """Should return Created, location header and no body."""
     url = f"{http_service}/competition-formats"
@@ -78,7 +109,32 @@ async def test_create_competition_format(
         hdrs.CONTENT_TYPE: "application/json",
         hdrs.AUTHORIZATION: f"Bearer {token}",
     }
-    request_body = competition_format
+    request_body = competition_format_interval_start
+
+    session = ClientSession()
+    async with session.post(url, headers=headers, json=request_body) as response:
+        status = response.status
+    await session.close()
+
+    assert status == 201
+    assert "/competition-formats/" in response.headers[hdrs.LOCATION]
+
+
+@pytest.mark.contract
+@pytest.mark.asyncio
+async def test_create_competition_format_individual_sprint(
+    http_service: Any,
+    token: MockFixture,
+    clear_db: AsyncGenerator,
+    competition_format_individual_sprint: dict,
+) -> None:
+    """Should return Created, location header and no body."""
+    url = f"{http_service}/competition-formats"
+    headers = {
+        hdrs.CONTENT_TYPE: "application/json",
+        hdrs.AUTHORIZATION: f"Bearer {token}",
+    }
+    request_body = competition_format_individual_sprint
 
     session = ClientSession()
     async with session.post(url, headers=headers, json=request_body) as response:
@@ -114,7 +170,7 @@ async def test_get_all_competition_formats(
 @pytest.mark.contract
 @pytest.mark.asyncio
 async def test_get_competition_format_by_id(
-    http_service: Any, token: MockFixture, competition_format: dict
+    http_service: Any, token: MockFixture, competition_format_individual_sprint: dict
 ) -> None:
     """Should return OK and an competition_format as json."""
     url = f"{http_service}/competition-formats"
@@ -124,7 +180,8 @@ async def test_get_competition_format_by_id(
     }
 
     async with ClientSession() as session:
-        async with session.get(url, headers=headers) as response:
+        query_param = f'name={quote(competition_format_individual_sprint["name"])}'
+        async with session.get(f"{url}?{query_param}", headers=headers) as response:
             competition_formats = await response.json()
         id = competition_formats[0]["id"]
         url = f"{url}/{id}"
@@ -133,47 +190,66 @@ async def test_get_competition_format_by_id(
 
     assert response.status == 200
     assert "application/json" in response.headers[hdrs.CONTENT_TYPE]
-    assert type(competition_format) is dict
+    assert type(competition_format_individual_sprint) is dict
     assert body["id"] == id
-    assert body["name"] == competition_format["name"]
-    assert body["starting_order"] == competition_format["starting_order"]
-    assert body["start_procedure"] == competition_format["start_procedure"]
-    assert body["intervals"] == competition_format["intervals"]
+    assert body["name"] == competition_format_individual_sprint["name"]
+    assert (
+        body["starting_order"] == competition_format_individual_sprint["starting_order"]
+    )
+    assert (
+        body["start_procedure"]
+        == competition_format_individual_sprint["start_procedure"]
+    )
+    assert (
+        body["time_between_rounds"]
+        == competition_format_individual_sprint["time_between_rounds"]
+    )
+    assert (
+        body["time_between_heats"]
+        == competition_format_individual_sprint["time_between_heats"]
+    )
+    assert (
+        body["max_no_of_contestants"]
+        == competition_format_individual_sprint["max_no_of_contestants"]
+    )
 
 
 @pytest.mark.contract
 @pytest.mark.asyncio
 async def test_get_competition_format_by_name(
-    http_service: Any, token: MockFixture, competition_format: dict
+    http_service: Any, token: MockFixture, competition_format_interval_start: dict
 ) -> None:
     """Should return OK and an competition_format as json."""
     url = f"{http_service}/competition-formats"
-
     headers = {
         hdrs.AUTHORIZATION: f"Bearer {token}",
     }
 
     async with ClientSession() as session:
-        async with session.get(url, headers=headers) as response:
-            competition_formats = await response.json()
-        name = competition_formats[0]["name"]
-        url = f"{url}?name={name}"
-        async with session.get(url, headers=headers) as response:
+        query_param = f'name={quote(competition_format_interval_start["name"])}'
+        async with session.get(f"{url}?{query_param}", headers=headers) as response:
+            assert str(response.url) == f"{url}?name=Interval%20Start"
             body = await response.json()
 
     assert response.status == 200
     assert "application/json" in response.headers[hdrs.CONTENT_TYPE]
     assert type(body) is list
+    assert len(body) == 1
     assert body[0]["id"]
-    assert body[0]["name"] == competition_format["name"]
-    assert body[0]["starting_order"] == competition_format["starting_order"]
-    assert body[0]["start_procedure"] == competition_format["start_procedure"]
+    assert body[0]["name"] == competition_format_interval_start["name"]
+    assert (
+        body[0]["starting_order"] == competition_format_interval_start["starting_order"]
+    )
+    assert (
+        body[0]["start_procedure"]
+        == competition_format_interval_start["start_procedure"]
+    )
 
 
 @pytest.mark.contract
 @pytest.mark.asyncio
-async def test_update_competition_format(
-    http_service: Any, token: MockFixture, competition_format: dict
+async def test_update_competition_format_interval_start(
+    http_service: Any, token: MockFixture, competition_format_interval_start: dict
 ) -> None:
     """Should return No Content."""
     url = f"{http_service}/competition-formats"
@@ -188,7 +264,39 @@ async def test_update_competition_format(
         id = competition_formats[0]["id"]
         url = f"{url}/{id}"
 
-        request_body = deepcopy(competition_format)
+        request_body = deepcopy(competition_format_interval_start)
+        new_name = "Interval Start updated"
+        request_body["id"] = id
+        request_body["name"] = new_name
+
+        async with session.put(url, headers=headers, json=request_body) as response:
+            assert response.status == 204
+
+        async with session.get(url, headers=headers) as response:
+            assert response.status == 200
+            updated_competition_format = await response.json()
+            assert updated_competition_format["name"] == new_name
+
+
+@pytest.mark.contract
+@pytest.mark.asyncio
+async def test_update_competition_format_individual_sprint(
+    http_service: Any, token: MockFixture, competition_format_individual_sprint: dict
+) -> None:
+    """Should return No Content."""
+    url = f"{http_service}/competition-formats"
+    headers = {
+        hdrs.CONTENT_TYPE: "application/json",
+        hdrs.AUTHORIZATION: f"Bearer {token}",
+    }
+
+    async with ClientSession() as session:
+        async with session.get(url, headers=headers) as response:
+            competition_formats = await response.json()
+        id = competition_formats[0]["id"]
+        url = f"{url}/{id}"
+
+        request_body = deepcopy(competition_format_individual_sprint)
         new_name = "Interval Start updated"
         request_body["id"] = id
         request_body["name"] = new_name

--- a/tests/contract/test_event_format.py
+++ b/tests/contract/test_event_format.py
@@ -75,6 +75,7 @@ async def competition_format(event_id: str) -> dict:
         "starting_order": "Draw",
         "start_procedure": "Interval Start",
         "intervals": "00:00:30",
+        "datatype": "interval_start",
     }
 
 

--- a/tests/files/competition_format.json
+++ b/tests/files/competition_format.json
@@ -2,5 +2,6 @@
   "name": "Interval Start",
   "starting_order": "Draw",
   "start_procedure": "Interval Start",
-  "intervals": "00:00:30"
+  "intervals": "00:00:30",
+  "datatype": "interval_start"
 }

--- a/tests/integration/test_events.py
+++ b/tests/integration/test_events.py
@@ -50,6 +50,7 @@ async def competition_format() -> dict[str, str]:
         "starting_order": "Draw",
         "start_procedure": "Interval Start",
         "intervals": "00:00:30",
+        "datatype": "interval_start",
     }
 
 


### PR DESCRIPTION
Add support for individual sprint model
closes #55 