### PR TITLE
157 mulighet for å definere lavest lovlige startnummer ved tildeling

### DIFF
--- a/event_service/adapters/competition_formats_adapter.py
+++ b/event_service/adapters/competition_formats_adapter.py
@@ -10,7 +10,9 @@ from aiohttp import ClientSession
 
 from .adapter import Adapter
 
-COMPETITION_FORMAT_HOST_SERVER = os.getenv("COMPETITION_FORMAT_HOST_SERVER", "competition-format.example.com")
+COMPETITION_FORMAT_HOST_SERVER = os.getenv(
+    "COMPETITION_FORMAT_HOST_SERVER", "competition-format.example.com"
+)
 COMPETITION_FORMAT_HOST_PORT = os.getenv("COMPETITION_FORMAT_HOST_PORT", "8080")
 
 

--- a/event_service/app.py
+++ b/event_service/app.py
@@ -73,7 +73,7 @@ async def create_app() -> web.Application:
         ]
     )
 
-    async def mongo_context(app: Application) ->  AsyncGenerator[None]:
+    async def mongo_context(app: Application) -> AsyncGenerator[None]:
         # Set up database connection:
         logging.debug(f"Connecting to db at {DB_HOST}:{DB_PORT}")
         mongo = motor.motor_asyncio.AsyncIOMotorClient(

--- a/event_service/commands/contestants_commands.py
+++ b/event_service/commands/contestants_commands.py
@@ -43,7 +43,7 @@ class ContestantsCommands:
     """Class representing a commands on contestants."""
 
     @classmethod
-    async def assign_bibs( # noqa: C901
+    async def assign_bibs(  # noqa: C901
         cls: Any, db: Any, event_id: str, start_bib: int | None = 1
     ) -> None:
         """Assign bibs function.

--- a/event_service/commands/contestants_commands.py
+++ b/event_service/commands/contestants_commands.py
@@ -43,7 +43,9 @@ class ContestantsCommands:
     """Class representing a commands on contestants."""
 
     @classmethod
-    async def assign_bibs(cls: Any, db: Any, event_id: str) -> None:  # noqa: C901
+    async def assign_bibs( # noqa: C901
+        cls: Any, db: Any, event_id: str, start_bib: int | None = 1
+    ) -> None:
         """Assign bibs function.
 
         This function will
@@ -54,6 +56,7 @@ class ContestantsCommands:
         Arguments:
             db: the database to use
             event_id: the id of the event
+            start_bib: the bib number to start with
 
         Raises:
             EventNotFoundError: event not found
@@ -115,9 +118,9 @@ class ContestantsCommands:
             _list, key=lambda k: (k["raceclass_group"], k["raceclass_order"])
         )
         # For every contestant, assign unique bib
-        bib_no = 0
+        bib_no = start_bib - 1 if start_bib is not None else 0
         for d in _list_sorted_on_raceclass:
-            bib_no += 1  # noqa: SIM113
+            bib_no += 1
             d["bib"] = bib_no
 
         # finally update contestant record:
@@ -129,4 +132,4 @@ class ContestantsCommands:
             if _c.bib is None:  # pragma: no cover
                 msg = f"Bib number not assigned for contestant with id {_c.id}"
                 raise ValueError(msg)
-            await ContestantsService.update_contestant(db, event_id, _c.id, _c) # type: ignore [reportArgumentType]
+            await ContestantsService.update_contestant(db, event_id, _c.id, _c)  # type: ignore [reportArgumentType]

--- a/event_service/commands/events_commands.py
+++ b/event_service/commands/events_commands.py
@@ -43,13 +43,16 @@ class EventsCommands:
             else:
                 raceclass = raceclasses[0]
             # Update counter if raceclass exist:
-            if raceclass_exist and raceclass.id: # type: ignore [reportPossibleUnboundVariable]
-                raceclass.no_of_contestants += 1 # type: ignore [reportPossibleUnboundVariable]
+            if raceclass_exist and raceclass.id:  # type: ignore [reportPossibleUnboundVariable]
+                raceclass.no_of_contestants += 1  # type: ignore [reportPossibleUnboundVariable]
                 result = await RaceclassesService.update_raceclass(
-                    db, event_id, raceclass.id, raceclass # type: ignore [reportPossibleUnboundVariable]
+                    db,
+                    event_id,
+                    raceclass.id,  # type: ignore [reportPossibleUnboundVariable]
+                    raceclass,  # type: ignore [reportPossibleUnboundVariable]
                 )
                 if not result:
-                    msg = f"Update of raceclass with id {raceclass.id} failed." # type: ignore [reportPossibleUnboundVariable]
+                    msg = f"Update of raceclass with id {raceclass.id} failed."  # type: ignore [reportPossibleUnboundVariable]
                     raise RaceclassUpdateError(msg) from None
             # If not found, we create the raceclass:
             else:

--- a/event_service/services/contestants_service.py
+++ b/event_service/services/contestants_service.py
@@ -240,14 +240,14 @@ class ContestantsService:
         }
         for _c in contestants_dict:
             result["total"] += 1
-            _c["event_id"] = event_id # type: ignore [reportIndexIssue]
+            _c["event_id"] = event_id  # type: ignore [reportIndexIssue]
             contestant_id = create_id()
-            _c["id"] = contestant_id # type: ignore [reportIndexIssue]
+            _c["id"] = contestant_id  # type: ignore [reportIndexIssue]
             # Validate contestant:
             try:
                 # datetime to string in isoformat:
                 try:
-                    if _c["registration_date_time"]: # type: ignore [reportArgumentType]
+                    if _c["registration_date_time"]:  # type: ignore [reportArgumentType]
                         _c["registration_date_time"] = datetime.strptime(  # noqa: DTZ007  # type: ignore [reportArgumentType]
                             _c["registration_date_time"],  # type: ignore [reportArgumentType]
                             "%d.%m.%Y %H:%M:%S",
@@ -395,14 +395,14 @@ async def _parse_contestants_sportsadmin(contestants: str) -> pd.DataFrame:
             "Team",
             "Betalt/påmeldt dato",
         ]
-        contestants_df = pd.read_csv( # noqa: PGH003 # type: ignore
+        contestants_df = pd.read_csv(  # noqa: PGH003 # type: ignore
             StringIO(contestants),
             sep=";",
             encoding="utf-8",
             dtype=str,
             skiprows=2,
             header=0,
-            usecols=cols, # noqa: PGH003 # type: ignore
+            usecols=cols,  # noqa: PGH003 # type: ignore
         )
         contestants_df.columns = [
             "ageclass",
@@ -444,13 +444,13 @@ async def _parse_contestants_i_sonen(contestants: str) -> pd.DataFrame:
             "Klasse",
             "Øvelse",
         ]
-        contestants_df = pd.read_csv( # noqa: PGH003 # type: ignore
+        contestants_df = pd.read_csv(  # noqa: PGH003 # type: ignore
             StringIO(contestants),
             sep=";",
             encoding="utf-8",
             dtype=str,
             header=0,
-            usecols=cols, # noqa: PGH003 # type: ignore
+            usecols=cols,  # noqa: PGH003 # type: ignore
         )
         # Need to map column names to dataclass:
         contestants_df.rename(

--- a/event_service/services/event_format_service.py
+++ b/event_service/services/event_format_service.py
@@ -94,8 +94,8 @@ class EventFormatService:
             return IntervalStartFormat.from_dict(event_format)
         if event_format["datatype"] == "individual_sprint":
             return IndividualSprintFormat.from_dict(event_format)
-        msg = f"Unsupported event format type: {event_format['datatype']}" # pragma: no cover
-        raise EventFormatNotSupportedError(msg) # pragma: no cover
+        msg = f"Unsupported event format type: {event_format['datatype']}"  # pragma: no cover
+        raise EventFormatNotSupportedError(msg)  # pragma: no cover
 
     @classmethod
     async def update_event_format(

--- a/event_service/services/events_service.py
+++ b/event_service/services/events_service.py
@@ -136,7 +136,7 @@ async def validate_event(db: Any, event: Event) -> None:
     # Validate date_of_event if set:
     if event.date_of_event:
         try:
-            date.fromisoformat(event.date_of_event) # type: ignore [reportArgumentType]
+            date.fromisoformat(event.date_of_event)  # type: ignore [reportArgumentType]
         except ValueError as e:
             msg = f'Date "{event.date_of_event}" has invalid format.'
             raise InvalidDateFormatError(msg) from e
@@ -144,7 +144,7 @@ async def validate_event(db: Any, event: Event) -> None:
     # Validate time_of_event if set:
     if event.time_of_event:
         try:
-            time.fromisoformat(event.time_of_event) # type: ignore [reportArgumentType]
+            time.fromisoformat(event.time_of_event)  # type: ignore [reportArgumentType]
         except ValueError as e:
             msg = f'Time "{event.time_of_event}" has invalid format.'
             raise InvalidDateFormatError(msg) from e

--- a/event_service/views/contestants.py
+++ b/event_service/views/contestants.py
@@ -128,13 +128,13 @@ class ContestantsView(View):
 
         if "multipart/form-data" in self.request.headers[hdrs.CONTENT_TYPE]:
             async for part in await self.request.multipart():
-                logging.debug(f"part.name {part.name}.") # type: ignore [reportOptionalMemberAccess]
-                if "text/csv" in part.headers[hdrs.CONTENT_TYPE]: # type: ignore [reportOptionalMemberAccess]
+                logging.debug(f"part.name {part.name}.")  # type: ignore [reportOptionalMemberAccess]
+                if "text/csv" in part.headers[hdrs.CONTENT_TYPE]:  # type: ignore [reportOptionalMemberAccess]
                     # process csv:
-                    contestants = (await part.read()).decode() # type: ignore [reportAttributeAccessIssue]
+                    contestants = (await part.read()).decode()  # type: ignore [reportAttributeAccessIssue]
                 else:
                     raise HTTPBadRequest(
-                        reason=f"File's content-type {part.headers[hdrs.CONTENT_TYPE]} not supported." # type: ignore [reportAttributeAccessIssue]
+                        reason=f"File's content-type {part.headers[hdrs.CONTENT_TYPE]} not supported."  # type: ignore [reportAttributeAccessIssue]
                     ) from None
                 try:
                     result = await ContestantsService.create_contestants(

--- a/event_service/views/contestants_commands.py
+++ b/event_service/views/contestants_commands.py
@@ -44,10 +44,23 @@ class ContestantsAssignBibsView(View):
         except Exception as e:
             raise e from e
 
+        # Check for the start-bib parameter:
+        start_bib = None
+        if "start-bib" in self.request.rel_url.query:
+            start_bib_query = self.request.rel_url.query["start-bib"]
+            try:
+                start_bib = int(start_bib_query)
+            except ValueError:  # pragma: no cover
+                raise HTTPBadRequest(
+                    reason=f"Invalid start-bib value: {start_bib_query}. Should be an integer."
+                ) from None
+
         # Execute command:
         event_id = self.request.match_info["eventId"]
         try:
-            await ContestantsCommands.assign_bibs(db, event_id)
+            await ContestantsCommands.assign_bibs(
+                db, event_id, start_bib if start_bib else None
+            )
         except (EventNotFoundError, NoRaceclassInEventError) as e:
             raise HTTPNotFound(reason=str(e)) from e
         except (

--- a/event_service/views/event_format.py
+++ b/event_service/views/event_format.py
@@ -64,7 +64,9 @@ class EventFormatView(View):
 
         try:
             event_format_id = await EventFormatService.create_event_format(
-                db, event_id, event_format  # type: ignore [reportAttributeAccessIssue]
+                db,
+                event_id,
+                event_format,  # type: ignore [reportAttributeAccessIssue]
             )
         except EventNotFoundError as e:
             raise HTTPNotFound(reason=str(e)) from e

--- a/tests/contract/test_assign_bibs.py
+++ b/tests/contract/test_assign_bibs.py
@@ -124,7 +124,7 @@ async def test_assign_bibs(
         async with session.post(url, headers=headers) as response:
             if response.status != 201:
                 body = await response.json()
-            assert response.status == 201, body["detail"] # type: ignore [reportAttributeAccessIssue]
+            assert response.status == 201, body["detail"]  # type: ignore [reportAttributeAccessIssue]
             assert f"/events/{event_id}/raceclasses" in response.headers[hdrs.LOCATION]
 
         # We need to work on the raceclasses:

--- a/tests/contract/test_assign_bibs_start_on_100.py
+++ b/tests/contract/test_assign_bibs_start_on_100.py
@@ -1,0 +1,210 @@
+"""Contract test cases for contestants."""
+
+import logging
+import os
+from collections.abc import AsyncGenerator
+from datetime import date
+from typing import Any
+
+import motor.motor_asyncio
+import pytest
+from aiohttp import ClientSession, hdrs
+from pytest_mock import MockFixture
+
+from event_service.utils import db_utils
+
+USERS_HOST_SERVER = os.getenv("USERS_HOST_SERVER")
+USERS_HOST_PORT = os.getenv("USERS_HOST_PORT")
+DB_HOST = os.getenv("DB_HOST", "localhost")
+DB_PORT = int(os.getenv("DB_PORT", 27017))
+DB_NAME = os.getenv("DB_NAME", "events_test")
+DB_USER = os.getenv("DB_USER")
+DB_PASSWORD = os.getenv("DB_PASSWORD")
+
+
+@pytest.fixture(scope="module", autouse=True)
+async def token(http_service: Any) -> str:
+    """Create a valid token."""
+    url = f"http://{USERS_HOST_SERVER}:{USERS_HOST_PORT}/login"
+    headers = {hdrs.CONTENT_TYPE: "application/json"}
+    request_body = {
+        "username": os.getenv("ADMIN_USERNAME"),
+        "password": os.getenv("ADMIN_PASSWORD"),
+    }
+    session = ClientSession()
+    async with session.post(url, headers=headers, json=request_body) as response:
+        body = await response.json()
+    await session.close()
+    if response.status != 200:
+        logging.error(f"Got unexpected status {response.status} from {http_service}.")
+    return body["token"]
+
+
+@pytest.fixture(scope="module", autouse=True)
+async def clear_db() -> AsyncGenerator:
+    """Clear db before and after tests."""
+    mongo = motor.motor_asyncio.AsyncIOMotorClient(
+        host=DB_HOST, port=DB_PORT, username=DB_USER, password=DB_PASSWORD
+    )
+    try:
+        await db_utils.drop_db_and_recreate_indexes(mongo, DB_NAME)
+    except Exception as error:
+        logging.exception(f"Failed to drop database {DB_NAME}: {error}")
+        raise error
+
+    yield
+
+    try:
+        await db_utils.drop_db(mongo, DB_NAME)
+    except Exception as error:
+        logging.exception(f"Failed to drop database {DB_NAME}: {error}")
+        raise error
+
+
+@pytest.fixture(scope="module")
+async def event_id(
+    http_service: Any,
+    token: MockFixture,
+    clear_db: AsyncGenerator,
+) -> str | None:
+    """Create an event object for testing."""
+    url = f"{http_service}/events"
+    headers = {
+        hdrs.CONTENT_TYPE: "application/json",
+        hdrs.AUTHORIZATION: f"Bearer {token}",
+    }
+    request_body = {
+        "name": "Oslo Skagen sprint",
+        "date_of_event": date(2021, 8, 31).isoformat(),
+        "organiser": "Lyn Ski",
+        "webpage": "https://example.com",
+        "information": "Testarr for å teste den nye løysinga.",
+    }
+    session = ClientSession()
+    async with session.post(url, headers=headers, json=request_body) as response:
+        status = response.status
+    await session.close()
+    if status == 201:
+        # return the event_id, which is the last item of the path
+        event_id = response.headers[hdrs.LOCATION].split("/")[-1]
+        logging.debug(f"Created event with id {event_id}.")
+        return event_id
+    logging.error(f"Got unsuccesful status when creating event: {status}.")
+    return None
+
+
+@pytest.mark.contract
+async def test_assign_bibs_start_on_100(
+    http_service: Any,
+    token: MockFixture,
+    event_id: str,
+) -> None:
+    """Should return 201 Created and a location header with url to contestants."""
+    headers = {
+        hdrs.AUTHORIZATION: f"Bearer {token}",
+    }
+
+    async with ClientSession() as session:
+        # ARRANGE #
+
+        # First we need to assert that we have an event:
+        url = f"{http_service}/events/{event_id}"
+        logging.debug(f"Verifying event with id {event_id} at url {url}.")
+        async with session.get(url) as response:
+            assert response.status == 200
+
+        # Then we add contestants to event:
+        url = f"{http_service}/events/{event_id}/contestants"
+        files = {"file": open("tests/files/contestants_iSonen.csv", "rb")}
+        async with session.post(url, headers=headers, data=files) as response:
+            assert response.status == 200
+
+        # We need to generate raceclasses for the event:
+        url = f"{http_service}/events/{event_id}/generate-raceclasses"
+        async with session.post(url, headers=headers) as response:
+            if response.status != 201:
+                body = await response.json()
+            assert response.status == 201, body["detail"]  # type: ignore [reportAttributeAccessIssue]
+            assert f"/events/{event_id}/raceclasses" in response.headers[hdrs.LOCATION]
+
+        start_bib = 100
+        # ACT #
+
+        # Finally assign bibs to all contestants:
+        url = f"{http_service}/events/{event_id}/contestants/assign-bibs?start-bib={start_bib}"
+        async with session.post(url, headers=headers) as response:
+            if response.status != 201:
+                body = await response.json()
+            assert response.status == 201, body  # type: ignore [reportAttributeAccessIssue]
+            assert f"/events/{event_id}/contestants" in response.headers[hdrs.LOCATION]
+
+        # ASSERT #
+
+        # We check that bibs are actually assigned:
+        url = response.headers[hdrs.LOCATION]
+        async with session.get(url) as response:
+            contestants = await response.json()
+            assert response.status == 200
+            assert "application/json" in response.headers[hdrs.CONTENT_TYPE]
+            assert type(contestants) is list
+            assert len(contestants) > 0
+
+            # Check that all bib values are ints:
+            assert all(
+                isinstance(o, (int)) for o in [c.get("bib", None) for c in contestants]
+            )
+
+            # Checkt that list is sorted and consecutive:
+            assert sorted(set([c["bib"] for c in contestants])) == list(
+                range(
+                    min(set([c["bib"] for c in contestants])),
+                    max(set([c["bib"] for c in contestants])) + 1,
+                )
+            )
+
+            # Check that the first bib is 100:
+            assert contestants[0]["bib"] == start_bib
+
+
+# ---
+
+
+async def _print_raceclasses(raceclasses: list[dict]) -> None:
+    # print("--- RACECLASSES ---")
+    # print("group;order;name;ageclasses;no_of_contestants;distance;ranking;event_id")
+    # for raceclass in raceclasses:
+    #     print(
+    #         str(raceclass["group"])
+    #         + ";"
+    #         + str(raceclass["order"])
+    #         + ";"
+    #         + raceclass["name"]
+    #         + ";"
+    #         + "".join(raceclass["ageclasses"])
+    #         + ";"
+    #         + str(raceclass["no_of_contestants"])
+    #         + ";"
+    #         + str(raceclass["distance"])
+    #         + ";"
+    #         + str(raceclass["ranking"])
+    #         + ";"
+    #         + str(raceclass["seeding"])
+    #         + ";"
+    #         + raceclass["event_id"]
+    #     )
+    pass
+
+
+async def _print_contestants(contestants: list[dict]) -> None:
+    # print("--- CONTESTANTS ---")
+    # print(f"Number of contestants: {len(contestants)}.")
+    # print("bib;ageclass")
+    # for contestant in contestants:
+    #     print(str(contestant["bib"]) + ";" + str(contestant["ageclass"]))
+    pass
+
+
+async def _dump_contestants_to_json(contestants: list[dict]) -> None:
+    # with open("tests/files/tmp_startlist.json", "w") as file:
+    #     json.dump(contestants, file)
+    pass

--- a/tests/integration/test_assign_bibs_to_contestants.py
+++ b/tests/integration/test_assign_bibs_to_contestants.py
@@ -197,6 +197,7 @@ async def test_assign_bibs_to_contestants(
         assert resp.status == 201
         assert f"/events/{event_id}/contestants" in resp.headers[hdrs.LOCATION]
 
+
 @pytest.mark.integration
 async def test_assign_bibs_to_contestants_start_bib_100(
     client: _TestClient,
@@ -245,6 +246,7 @@ async def test_assign_bibs_to_contestants_start_bib_100(
         )
         assert resp.status == 201
         assert f"/events/{event_id}/contestants" in resp.headers[hdrs.LOCATION]
+
 
 # Bad cases
 @pytest.mark.integration

--- a/tests/integration/test_contestants.py
+++ b/tests/integration/test_contestants.py
@@ -796,7 +796,9 @@ async def test_create_contestants_csv_good_case_octet_stream(
         }
 
         with aioresponses(passthrough=["http://127.0.0.1"]) as m:
-            m.post(f"http://{USERS_HOST_SERVER}:{USERS_HOST_PORT}/authorize", status=204)
+            m.post(
+                f"http://{USERS_HOST_SERVER}:{USERS_HOST_PORT}/authorize", status=204
+            )
             resp = await client.post(
                 f"/events/{EVENT_ID}/contestants", headers=headers, data=f
             )
@@ -1241,7 +1243,9 @@ async def test_create_contestants_csv_octet_stream_event_not_found(
         }
 
         with aioresponses(passthrough=["http://127.0.0.1"]) as m:
-            m.post(f"http://{USERS_HOST_SERVER}:{USERS_HOST_PORT}/authorize", status=204)
+            m.post(
+                f"http://{USERS_HOST_SERVER}:{USERS_HOST_PORT}/authorize", status=204
+            )
             resp = await client.post(
                 f"/events/{EVENT_ID}/contestants", headers=headers, data=f
             )

--- a/tests/integration/test_event_format.py
+++ b/tests/integration/test_event_format.py
@@ -17,6 +17,7 @@ load_dotenv()
 USERS_HOST_SERVER = os.getenv("USERS_HOST_SERVER")
 USERS_HOST_PORT = os.getenv("USERS_HOST_PORT")
 
+
 @pytest.fixture
 def token() -> str:
     """Create a valid token."""


### PR DESCRIPTION
Solves #157  

Added an optional query-parameter `start-bib` (int) that can be used as follows:
```
# Assign bibs to all contestants starting on 100:
start_bib = 100
url = f"{http_service}/events/{event_id}/contestants/assign-bibs?start-bib={start_bib}"
async with session.post(url, headers=headers) as response:
```
Default value is 1.